### PR TITLE
Include offset binarySchema

### DIFF
--- a/lib/binarySchema.js
+++ b/lib/binarySchema.js
@@ -41,6 +41,7 @@ BinarySchema.decodeMessage = function(msg) {
     return {
         'key': utils.fromBase64(msg.key),
         'value': utils.fromBase64(msg.value),
-        'partition': msg.partition
+        'partition': msg.partition,
+        'offset': msg.offset
     };
 };


### PR DESCRIPTION
Offset is missing from the message when using binary encoding.