### PR TITLE
Expose internal classes

### DIFF
--- a/lib/brokers.js
+++ b/lib/brokers.js
@@ -32,7 +32,7 @@ Brokers.prototype.list = function(res) {
     }.bind(this));
 }
 
-var Broker = function(client, id, raw) {
+var Broker = Brokers.Broker = function(client, id, raw) {
     this.client = client;
     this.id = id;
     this.raw = raw;

--- a/lib/consumers.js
+++ b/lib/consumers.js
@@ -41,7 +41,7 @@ Consumers.prototype.group = function(groupName) {
  * @param groupName
  * @constructor
  */
-var Consumer = function(client, groupName) {
+var Consumer = Consumers.Consumer = function(client, groupName) {
     this.client = client;
     this.groupName = groupName;
     this.schemaClass = BinarySchema; // Default binary mode
@@ -81,7 +81,7 @@ Consumer.prototype.toString = function() {
  * @param raw
  * @constructor
  */
-var ConsumerInstance = function(consumer, raw) {
+var ConsumerInstance = Consumers.ConsumerInstance = function(consumer, raw) {
     EventEmitter.call(this);
 
     this.client = consumer.client;
@@ -152,7 +152,7 @@ ConsumerInstance.prototype.getUri = function() {
 
 
 
-var ConsumerStream = function(instance, topic, options) {
+var ConsumerStream = Consumers.ConsumerStream = function(instance, topic, options) {
     Readable.call(this, {'objectMode' : true});
 
     this.client = instance.client;

--- a/lib/partitions.js
+++ b/lib/partitions.js
@@ -58,7 +58,7 @@ Partitions.prototype.partition = function(id) {
 }
 
 
-var Partition = function(client, topic, id, raw) {
+var Partition = Partitions.Partition = function(client, topic, id, raw) {
     this.client = client;
     this.topic = topic;
     this.id = id;

--- a/lib/topics.js
+++ b/lib/topics.js
@@ -60,7 +60,7 @@ Topics.prototype.topic = function(name) {
  * Create a new Topic object with the given name, optionally providing the raw
  * JSON source.
  */
-var Topic = function(client, name, raw) {
+var Topic = Topics.Topic = function(client, name, raw) {
     this.client = client;
     this.name = name;
     utils.mixin(this, raw);


### PR DESCRIPTION
It may be useful for users to have access to internal classes. For example, if you prefer to use promises instead of callbacks, this allows you to promisify the prototype once instead of on each instance.

Example:

````javascript
var Bluebird = require('bluebird'),
    Client   = require('kafka-rest');

Bluebird.promisifyAll(Client.prototype);
````