### PR TITLE
Implement stream interface with back-pressure

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ will be created. You can then subscribe to a topic, resulting in a
 `ConsumerStream`, and setup event handlers:
 
     var stream = consumer_instance.subscribe('my-topic')
-    stream.on('read', function(msgs) {
+    stream.on('data', function(msgs) {
         for(var i = 0; i < msgs.length; i++)
             console.log("Got a message: key=" + msgs[i].key + " value=" + msgs[i].value + " partition=" + msgs[i].partition);
     });

--- a/examples/console_consumer.js
+++ b/examples/console_consumer.js
@@ -49,7 +49,7 @@ kafka.consumer(consumerGroup).join(consumerConfig, function(err, consumer_instan
 
     console.log("Consumer instance initialized: " + consumer_instance.toString());
     var stream = consumer_instance.subscribe(topicName);
-    stream.on('read', function(msgs) {
+    stream.on('data', function(msgs) {
         for(var i = 0; i < msgs.length; i++) {
             if (format == "binary") {
                 // Messages keys (if available) and values are decoded from base64 into Buffers. You'll need to decode based

--- a/examples/twitter/trending.js
+++ b/examples/twitter/trending.js
@@ -56,7 +56,7 @@ kafka.consumer(consumerGroup).join(consumerConfig, function(err, ci) {
     if (err) return console.log("Failed to create instance in consumer group: " + err);
     consumer_instance = ci;
     var stream = consumer_instance.subscribe(topicName);
-    stream.on('read', function(msgs) {
+    stream.on('data', function(msgs) {
         for(var i = 0; i < msgs.length; i++) {
             var tweet = (binary ? JSON.parse(msgs[i].value.toString('utf8')) : msgs[i].value);
             processTweet(tweet);

--- a/lib/consumers.js
+++ b/lib/consumers.js
@@ -22,6 +22,7 @@ var utils = require('./utils'),
     AvroSchema = require('./avroSchema'),
     util = require('util'),
     EventEmitter = require('events').EventEmitter,
+    Readable = require('stream').Readable,
     async = require('async');
 
 var Consumers = module.exports = function(client) {
@@ -152,7 +153,7 @@ ConsumerInstance.prototype.getUri = function() {
 
 
 var ConsumerStream = function(instance, topic, options) {
-    EventEmitter.call(this);
+    Readable.call(this, {'objectMode' : true});
 
     this.client = instance.client;
     this.instance = instance;
@@ -161,11 +162,10 @@ var ConsumerStream = function(instance, topic, options) {
     this.schemaClass = this.instance.consumer.schemaClass;
 
     this.active = true;
-    this.read();
 }
-util.inherits(ConsumerStream, EventEmitter);
+util.inherits(ConsumerStream, Readable);
 
-ConsumerStream.prototype.read = function() {
+ConsumerStream.prototype._read = function() {
     var acceptContentType = this.schemaClass.getContentType(this.client);
     this.client.request({'url' : this.getUri(), 'accept': acceptContentType}, function(err, msgs) {
         if (err) {
@@ -180,18 +180,17 @@ ConsumerStream.prototype.read = function() {
                 for(var i = 0; i < msgs.length; i++) {
                     decoded_msgs.push(this.schemaClass.decodeMessage(msgs[i]));
                 }
-                this.emit('read', decoded_msgs);
+                this.push(decoded_msgs);
                 this.instance.emit('read', decoded_msgs);
-            }
-            if (this.active) {
+            } else if (this.active) {
                 if(this.options.requestDelay) {
-                    setTimeout(this.read.bind(this), this.options.requestDelay);
+                    setTimeout(this._read.bind(this), this.options.requestDelay);
                 } else {
-                    this.read();
+                    this._read();
                 }
-            } else {
-                this.emit('end');
-                if (this.end_cb) this.end_cb();
+            }
+            if (!this.active) {
+                this.push(null);
             }
         }
     }.bind(this));
@@ -199,7 +198,7 @@ ConsumerStream.prototype.read = function() {
 
 ConsumerStream.prototype.shutdown = function(res) {
     // Just mark as no longer active, read callback will clean up
-    this.end_cb = res;
+    this.on('end', res);
     this.active = false;
 }
 


### PR DESCRIPTION
The current `ConsumerStream` interface is close to a node `Readable` stream, but does not exactly implement it. By implementing the `Readable` interface, it is easier to connect to other streams as well as support back-pressure.

From an end-user's perspective, the only change is to listen on the `data` event instead of `read`.