### PR TITLE
#12 Ability to pull messages by offset

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ the path to and don't want to do API calls on the intermediate resources
 (i.e. get a single partition, but don't look up topic metadata):
 
     // The complete version makes the resource hierarchy clear
-    kafka.topics.topic('test').partitions().partition(0);
+    kafka.topics.topic('test').partitions.partition(0);
     // Or use the shorter version. Under the hood they do the same thing, so you
     // can use whichever is clearer based on context
     kafka.topic('test').partition(0);

--- a/lib/partitionMessages.js
+++ b/lib/partitionMessages.js
@@ -42,7 +42,7 @@ PartitionMessages.prototype.messages = function(options, res) {
     options = options || {};
 
     // Ensure that offset is passed in
-    if (typeof options === 'function' || !options.offset) {
+    if (typeof options === 'function' || options.offset === undefined || options.offset === null) {
         var callback = res || options;
         return callback(new Error('Offset is required'));
     }

--- a/lib/partitionMessages.js
+++ b/lib/partitionMessages.js
@@ -15,7 +15,9 @@
  */
 "use strict";
 
-var utils = require('./utils');
+var utils = require('./utils'),
+    avroSchema = require('./avroSchema'),
+    binarySchema = require('./binarySchema');
 
 /**
  * PartitionMessages resource, scoped to a single Partition.
@@ -72,13 +74,11 @@ PartitionMessages.prototype.getQueryString = function(query) {
 }
 
 PartitionMessages.prototype.getContentType = function(format) {
-    var version = this.client.config.version;
-
     switch (format) {
         case 'avro':
-            return "application/vnd.kafka.avro.v" + version + "+json";
+            return avroSchema.getContentType(this.client);
         case 'binary':
-            return 'application/vnd.kafka.binary.v' + version + '+json';
+            return binarySchema.getContentType(this.client);
         case 'json':
         default:
             return null;

--- a/lib/partitionMessages.js
+++ b/lib/partitionMessages.js
@@ -1,0 +1,88 @@
+/**
+ * Copyright 2014 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+"use strict";
+
+var utils = require('./utils');
+
+/**
+ * PartitionMessages resource, scoped to a single Partition.
+ * @type {Function}
+ */
+var PartitionMessages = module.exports = function(partition) {
+    this.client = partition.client;
+    this.partition = partition;
+}
+
+/**
+ * Request a specified number of messages from a specified offset
+ *
+ * type options {
+ *      offset: number,
+ *      count: ?number,
+ *      format: ?string (json, avro, binary)
+ *  }
+ *
+ * @param options
+ * @param res function(err, messages)
+ */
+PartitionMessages.prototype.messages = function(options, res) {
+    options = options || {};
+
+    // Ensure that offset is passed in
+    if (typeof options === 'function' || !options.offset) {
+        var callback = res || options;
+        return callback(new Error('Offset is required'));
+    }
+
+    var query = { offset: options.offset };
+
+    // Count is optional
+    if (options.count) query.count = options.count;
+
+    var reqOpts = {
+        path: this.getPath() + this.getQueryString(query),
+        accept: this.getContentType(options.format)
+    };
+
+    this.client.request(reqOpts, function(err, messages_raw) {
+        if (err) return res(err);
+        this.raw = messages_raw;
+        res(null, this);
+    }.bind(this));
+}
+
+PartitionMessages.prototype.getPath = function() {
+    return utils.urlJoin(this.partition.getPath(), "messages");
+}
+
+PartitionMessages.prototype.getQueryString = function(query) {
+    return utils.urlQueryString(query);
+}
+
+PartitionMessages.prototype.getContentType = function(format) {
+    var version = this.client.config.version;
+
+    switch (format) {
+        case 'avro':
+            return "application/vnd.kafka.avro.v" + version + "+json";
+        case 'binary':
+            return 'application/vnd.kafka.binary.v' + version + '+json';
+        case 'json':
+        default:
+            return null;
+
+    }
+}

--- a/lib/partitionMessages.js
+++ b/lib/partitionMessages.js
@@ -57,10 +57,9 @@ PartitionMessages.prototype.messages = function(options, res) {
         accept: this.getContentType(options.format)
     };
 
-    this.client.request(reqOpts, function(err, messages_raw) {
+    this.client.request(reqOpts, function(err, messages) {
         if (err) return res(err);
-        this.raw = messages_raw;
-        res(null, this);
+        res(null, messages);
     }.bind(this));
 }
 

--- a/lib/partitions.js
+++ b/lib/partitions.js
@@ -16,7 +16,8 @@
 "use strict";
 
 var utils = require('./utils'),
-    messages = require('./messages');
+    messages = require('./messages'),
+    PartitionMessages = require('./partitionMessages');
 
 /**
  * Partitions resource, scoped to a single Topic.
@@ -129,6 +130,19 @@ Partition.prototype.produce = function() {
         }
     }.bind(this));
 }
+
+/**
+ * Get a Partitions resource representing the partitions for this topic. This does not request any metadata since you may
+ * use the Partitions resource to get a specific partition; call list() on the resulting Partitions resource to get a
+ * full listing with metadata.
+ *
+ * @param res function(err,
+ */
+Partition.prototype.__defineGetter__("messages", function() {
+    if (!this._messages)
+        this._messages = new PartitionMessages(this);
+    return this._messages.messages.bind(this._messages);
+});
 
 Partition.prototype.toString = function() {
     var result = "Partition{topic=\"" + this.topic.name + "\"" +

--- a/lib/partitions.js
+++ b/lib/partitions.js
@@ -132,10 +132,9 @@ Partition.prototype.produce = function() {
 }
 
 /**
- * Get a Partitions resource representing the partitions for this topic. This does not request any metadata since you may
- * use the Partitions resource to get a specific partition; call list() on the resulting Partitions resource to get a
- * full listing with metadata.
+ * Consume messages from one partition of the topic.
  *
+ * @param options
  * @param res function(err,
  */
 Partition.prototype.__defineGetter__("messages", function() {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -45,6 +45,20 @@ exports.urlJoin = function() {
     return path;
 }
 
+exports.urlQueryString = function(query) {
+    query = query || {};
+    var queryString = '?';
+    var params = [];
+
+    for (var key in query) {
+        params.push(key + '=' + encodeURIComponent(query[key]));
+    }
+
+    return params.length > 0
+        ? '?' + params.join('&')
+        : '';
+}
+
 exports.toBase64 = function(val) {
     if (val === null || val == undefined)
         return null;


### PR DESCRIPTION
Fix #12 

Added the ability to request for messages on a partition by specifying the offset to start from.

See http://docs.confluent.io/2.0.0/kafka-rest/docs/api.html#get--topics-(string-topic_name)-partitions-(int-partition_id)-messages?offset=(int)%5B&count=(int)%5D